### PR TITLE
Merge Null Check Helpers

### DIFF
--- a/scripts/enemy/Enemy.cs
+++ b/scripts/enemy/Enemy.cs
@@ -16,9 +16,9 @@ public partial class Enemy : CharacterBody2D
 
     public override void _Ready()
     {
-        _visibilityNotifier = GetNode<VisibleOnScreenNotifier2D>("VisibleOnScreenNotifier2D").GDNotNull(nameof(_visibilityNotifier));
-        _hitbox = GetNode<Area2D>("Hitbox").GDNotNull(nameof(_hitbox));
-        _healthPool = GetNode<Health>("Health").GDNotNull(nameof(_healthPool));
+        _visibilityNotifier = GetNode<VisibleOnScreenNotifier2D>("VisibleOnScreenNotifier2D").NotNull(nameof(_visibilityNotifier));
+        _hitbox = GetNode<Area2D>("Hitbox").NotNull(nameof(_hitbox));
+        _healthPool = GetNode<Health>("Health").NotNull(nameof(_healthPool));
         _player = (Player)GetTree().Root.FindChildren("*", nameof(Player), true, false)[0].NotNull(nameof(_player));
 
         _hitbox.AreaEntered += OnHitboxAreaEntered;

--- a/scripts/helpers/Nullability.cs
+++ b/scripts/helpers/Nullability.cs
@@ -4,16 +4,11 @@ using Godot;
 
 public static class NullHelpers
 {
-    public static T NotNull<T>([NotNull] this T? obj, string objName)
+    public static T NotNull<T>([NotNull] this T? node, string objName)
     {
-        return obj ?? throw new ArgumentNullException(objName);
-    }
-
-    public static T GDNotNull<T>([NotNull] this T? node, string nodeName) where T : GodotObject
-    {
-        if (node == null || !GodotObject.IsInstanceValid(node))
+        if (node == null || (node is GodotObject gdObject && !GodotObject.IsInstanceValid(gdObject)))
         {
-            throw new ArgumentNullException(nodeName);
+            throw new ArgumentNullException(objName);
         }
 
         return node;


### PR DESCRIPTION
I've been forgetting to use the GDNotNull method, but it's what we should be using for most cases, so I've made it the default logic and removed the regular NotNull version.